### PR TITLE
Graverobber: Added logic to give gravs their original role back if no ankhs and "opt-out" hook

### DIFF
--- a/lua/terrortown/lang/en/pharaoh.lua
+++ b/lua/terrortown/lang/en/pharaoh.lua
@@ -42,6 +42,7 @@ L["ankh_revival_canceled"] = "Revival Canceled"
 L["ankh_revival_canceled_text"] = "Your revival was canceled because your ankh has been destroyed."
 L["ankh_insufficient_room"] = "Insufficient room."
 L["ankh_owner_is_reviving"] = "Conversion blocked - owner is reviving"
+L["ankh_all_gone"] = "All ankhs have been destroyed and so your old role has been returned to you."
 
 L["tooltip_ankh_conversion_score"] = "Ankh stolen: {score}"
 L["ankh_conversion_score"] = "Ankh stolen:"


### PR DESCRIPTION
This pull request makes two changes to the Graverobber:

1. Implements Tim's idea mentioned in https://github.com/TTT-2/ttt2-role_pha/pull/16, wherein if all ankhs are destroyed all Graverobbers are given back their original roles (I believe this implementation was their intention).
2. Adds the "TTT2GraverobberPreventSelection" hook, which can be used by special traitor roles to "opt-out" of being selected to become Graverobbers. I added this primarily for the Defective, as losing their Detective status right as an ankh is placed down is extremely sus and has no meaningful counterplay.

My local implementation of the above hook in the Defective code is as follows:
```lua
hook.Add("TTT2GraverobberPreventSelection", "DefectiveGraverobberPreventSelection", function(ply)
	if ply:GetSubRole() == ROLE_DEFECTIVE then
		return true
	end
end)
```
