### PR TITLE
Fixed typo with ttt_ankh_respawn_time

### DIFF
--- a/lua/terrortown/autorun/shared/sh_pharaoh_handler.lua
+++ b/lua/terrortown/autorun/shared/sh_pharaoh_handler.lua
@@ -772,7 +772,7 @@ if SERVER then
 		local ankh_pos = PHARAOH_HANDLER.ankhs[id].ankh:GetPos() + Vector(0, 0, 2.5)
 
 		victim:Revive(
-			GetConVar("ttt_ankh_respawn_time", 10):GetInt(), -- respawn delay
+			GetConVar("ttt_ankh_respawn_time"):GetInt(), -- respawn delay
 			function(ply) -- OnRevive function
 				-- set state to ank that a player is no longer reviving
 				PHARAOH_HANDLER.ankhs[id].ankh:SetNWBool("isReviving", false)


### PR DESCRIPTION
Typo is technically cosmetic (respawn works with/without the fix)